### PR TITLE
Draft: Grounding setup scaffolding (Issue #3)

### DIFF
--- a/docs/adr/ADR-0001-security-ux-notes.md
+++ b/docs/adr/ADR-0001-security-ux-notes.md
@@ -1,0 +1,31 @@
+# ADR-0001: Security UX notes for Wasm components (Wassette-inspired)
+
+Date: 2025-09-23
+Status: Draft
+Related: #3
+
+## Context
+We are introducing Wasm components that run under a lattice with capability providers. Users need visibility and control over what each component can access (network, storage, environment, secrets, logging).
+
+## Decision
+1. Default-deny posture with explicit capability manifests per component.
+2. Provide a Security dialog on each node to review and override proposed capabilities before build/run.
+3. Manifest sources: static analysis + node metadata → proposal; user edits → authoritative.
+4. Enforce at build time (bindings required) and runtime (policy + lattice bindings).
+
+## UX elements
+- Network: domain/IP allowlist + method constraints (GET/POST). Optional proxy.
+- Storage: KV/Blob scopes (buckets/paths) with read/write flags.
+- Env: explicit env var passthrough list; no wildcards by default.
+- Secrets: named references resolved at runtime; scopes (project/user).
+- Logging: default level and redaction hints for PII.
+
+## Consequences
+- Safer defaults; more friction initially when capabilities are missing.
+- Deterministic builds via manifests checked into the Component Twin.
+- Clear audit trail for overrides.
+
+## Follow-ups
+- Define manifest schema in the Component Twin.
+- Add validators and UI affordances for common pitfalls (e.g., wildcard network).
+- Connect to provider-specific policies at deployment time.

--- a/docs/wasm/capability_providers_matrix.md
+++ b/docs/wasm/capability_providers_matrix.md
@@ -1,0 +1,21 @@
+# wasmCloud capability providers matrix for Langflow
+
+This matrix captures initial capability providers and how they map to common Langflow node needs. It will evolve as we add concrete bindings and policy defaults.
+
+| Use case | Provider | Contract ID | Typical bindings | Notes |
+|---|---|---|---|---|
+| Outbound HTTP requests | HTTP Client | wasmcloud:httpclient | none by default; requires outbound network policy | Used by nodes calling external APIs. Honor allowlist/denylist and proxy settings. |
+| Key-value storage | KeyValue | wasmcloud:keyvalue | bucket/name; scope | Caching and lightweight state for nodes. |
+| Blob/object storage | BlobStore | wasmcloud:blobstore | container/bucket; path prefix | Large artifacts (wasm blobs, logs, datasets). |
+| Secrets retrieval | Secrets | wasmcloud:secrets | secret names/scopes | Resolve API keys, tokens at runtime without embedding. |
+| Structured logging | Logging | wasmcloud:logging | level, facility | Uniform component logs; surface in UI. |
+
+Conventions
+- Bindings are derived from each component's capability manifest (generated + user overrides).
+- Default posture is least-privilege. A build or run should fail fast if required bindings are missing.
+- Provider choice may vary by deployment (local dev vs. prod). Keep provider-agnostic contracts in manifests.
+
+Open questions
+- HTTP: should we model per-domain allowlists in the manifest or defer to zone policy only?
+- KV/Blob: naming and retention conventions across environments.
+- Secrets: link manifest entries to project/workspace secret stores with scopes.

--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -1,0 +1,45 @@
+# Langflow Wasm examples
+
+This directory contains a minimal Component Model example plus build notes. The goal is to prove: (1) a minimal WIT world, (2) a Rust skeleton that compiles to a component .wasm, and (3) compatibility with Wasmtime/wasmCloud.
+
+## Prereqs
+- Rust toolchain
+- One of:
+  - cargo-component (recommended)
+  - or wasm-tools + wit-bindgen CLI
+- Wasmtime for local runs
+
+On macOS:
+- brew install wasmtime wasm-tools
+- cargo install cargo-component
+- rustup target add wasm32-wasi
+
+## Build (cargo-component)
+From `examples/wasm/minimal-component`:
+
+```bash
+# If using cargo-component (generates component model artifacts)
+cargo component build --release
+```
+
+## Build (wasm-tools)
+```bash
+# 1) Build a core wasm artifact
+cargo build --target wasm32-wasi --release
+
+# 2) Wrap as a component using the WIT world
+wasm-tools component new target/wasm32-wasi/release/langflow-minimal-component.wasm \
+  -o target/release/langflow-minimal-component.component.wasm \
+  --adapt wasi_snapshot_preview1=wasi_snapshot_preview1.reactor.wasm \
+  --wit ./wit --world component
+```
+
+Note: exact flags may change with tool versions; see Wasmtime and wasm-tools docs.
+
+## Run (Wasmtime)
+```bash
+wasmtime component run target/release/langflow-minimal-component.component.wasm \
+  --invoke process -- "hello"
+```
+
+Expected: the component echoes the input string.

--- a/examples/wasm/minimal-component/Cargo.toml
+++ b/examples/wasm/minimal-component/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "langflow-minimal-component"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { version = "0.36", default-features = false, features = ["macros", "realloc"] }

--- a/examples/wasm/minimal-component/src/lib.rs
+++ b/examples/wasm/minimal-component/src/lib.rs
@@ -1,0 +1,18 @@
+// Minimal Rust skeleton for the `langflow:minimal` WIT world.
+// Note: Depending on your wit-bindgen/cargo-component versions, you may need to adjust the macros.
+
+wit_bindgen::generate!({
+    path: "wit",
+    world: "component"
+});
+
+struct Component;
+
+impl exports::langflow::minimal::component::Guest for Component {
+    fn process(input: String) -> String {
+        format!("echo: {}", input)
+    }
+}
+
+// Some toolchains expose an `export!` macro. If needed in your environment, uncomment:
+// wit_bindgen::export!(Component);

--- a/examples/wasm/minimal-component/wit/minimal.wit
+++ b/examples/wasm/minimal-component/wit/minimal.wit
@@ -1,0 +1,5 @@
+package langflow:minimal
+
+world component {
+    export process: func(input: string) -> string
+}


### PR DESCRIPTION
Refs #3

This draft PR seeds the groundwork for the Wasm/wasmCloud setup:

Includes
- docs/wasm/capability_providers_matrix.md — initial capability providers matrix (HTTP, KV, Blob, Secrets, Logging)
- docs/adr/ADR-0001-security-ux-notes.md — Wassette-inspired security UX notes (default-deny, manifests, overrides)
- examples/wasm/README.md — build/run notes (cargo-component / wasm-tools + Wasmtime)
- examples/wasm/minimal-component/wit/minimal.wit — minimal world definition
- examples/wasm/minimal-component/Cargo.toml — Rust component build config
- examples/wasm/minimal-component/src/lib.rs — minimal Rust impl (`process` echo)

Planned next commits in this PR
- Compile and run the minimal component under Wasmtime locally (Acceptance 1)
- Set up local wasmCloud lattice and demonstrate a wRPC call (Acceptance 2)
- Expand provider matrix with bindings guidance per use-case (Acceptance 3)
- Check in security UX doc as ADR and wire to UI outline (Acceptance 4)

Notes
- These files are intentionally isolated under docs/ and examples/ to avoid disrupting current app code paths; will iterate toward integration hooks next.